### PR TITLE
Add Depth Limitation Flag to Directory Tree Generator

### DIFF
--- a/rptree/__main__.py
+++ b/rptree/__main__.py
@@ -14,7 +14,7 @@ def main():
         print("The specified root directory doesn't exist")
         sys.exit()
     tree = DirectoryTree(
-        root_dir, dir_only=args.dir_only, output_file=args.output_file
+        root_dir, dir_only=args.dir_only, output_file=args.output_file, max_depth=args.level
     )
     tree.generate()
 

--- a/rptree/cli.py
+++ b/rptree/cli.py
@@ -35,4 +35,12 @@ def parse_cmd_line_arguments():
         default=sys.stdout,
         help="generate a full directory tree and save it to a file",
     )
+    parser.add_argument(
+        "-l",
+        "--level",
+        type=int,
+        metavar="LEVEL",
+        nargs="?",
+        help="limit the depth of the directory tree",
+    )
     return parser.parse_args()


### PR DESCRIPTION
This pull request adds a new feature to the RP Tree directory tree generator. Users can now limit the depth of the generated directory tree using the -l or --level flag. 

This enhancement allows for more control over the output, especially useful for large directory structures. 

The implementation includes modifications to the rptree.py, cli.py, and __main__.py files to support this new functionality.